### PR TITLE
usecseディレクトリにproject_input,project_outputを作成

### DIFF
--- a/pm/interfaces/handler/project.go
+++ b/pm/interfaces/handler/project.go
@@ -9,7 +9,6 @@ import (
 	"github.com/onituka/agile-project-management/project-management/apperrors"
 	"github.com/onituka/agile-project-management/project-management/interfaces/presenter"
 	"github.com/onituka/agile-project-management/project-management/usecase/projectusecse"
-	"github.com/onituka/agile-project-management/project-management/usecase/projectusecse/input"
 )
 
 type projectHandler struct {
@@ -23,7 +22,7 @@ func NewProjectHandler(projectUsecase projectusecse.ProjectUsecase) *projectHand
 }
 
 func (h *projectHandler) CreateProject(w http.ResponseWriter, r *http.Request) {
-	var in input.CreateProject
+	var in projectusecse.CreateProjectInput
 	if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
 		setAppErrorToCtx(r, err)
 		presenter.ErrorJSON(w, apperrors.InvalidParameter)
@@ -43,7 +42,7 @@ func (h *projectHandler) CreateProject(w http.ResponseWriter, r *http.Request) {
 func (h *projectHandler) UpdateProject(w http.ResponseWriter, r *http.Request) {
 	projectID := mux.Vars(r)["projectID"]
 
-	in := input.UpdateProject{
+	in := projectusecse.UpdateProjectInput{
 		ID: projectID,
 	}
 	if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
@@ -65,7 +64,7 @@ func (h *projectHandler) UpdateProject(w http.ResponseWriter, r *http.Request) {
 func (h *projectHandler) FetchProjectByID(w http.ResponseWriter, r *http.Request) {
 	projectID := mux.Vars(r)["projectID"]
 
-	in := input.FetchProjectByID{
+	in := projectusecse.FetchProjectByIDInput{
 		ID: projectID,
 	}
 

--- a/pm/usecase/projectusecse/project.go
+++ b/pm/usecase/projectusecse/project.go
@@ -7,16 +7,14 @@ import (
 	"github.com/onituka/agile-project-management/project-management/domain/groupdm"
 	"github.com/onituka/agile-project-management/project-management/domain/projectdm"
 	"github.com/onituka/agile-project-management/project-management/domain/userdm"
-	"github.com/onituka/agile-project-management/project-management/usecase/projectusecse/input"
-	"github.com/onituka/agile-project-management/project-management/usecase/projectusecse/output"
 	"github.com/onituka/agile-project-management/project-management/usecase/timemanager"
 )
 
 type ProjectUsecase interface {
-	CreateProject(ctx context.Context, in *input.CreateProject) (*output.CreateProject, error)
-	UpdateProject(ctx context.Context, in *input.UpdateProject) (*output.UpdateProject, error)
-	FetchProjectByID(ctx context.Context, in *input.FetchProjectByID) (*output.FetchProjectByID, error)
-	FetchProjects(ctx context.Context) (output.FetchProjects, error)
+	CreateProject(ctx context.Context, in *CreateProjectInput) (*CreateProjectOutput, error)
+	UpdateProject(ctx context.Context, in *UpdateProjectInput) (*UpdateProjectOutput, error)
+	FetchProjectByID(ctx context.Context, in *FetchProjectByIDInput) (*FetchProjectByIDOutput, error)
+	FetchProjects(ctx context.Context) (FetchProjectsOutput, error)
 }
 
 type projectUsecase struct {
@@ -31,7 +29,7 @@ func NewProjectUsecase(ProjectRepository projectdm.ProjectRepository, timeManage
 	}
 }
 
-func (u *projectUsecase) CreateProject(ctx context.Context, in *input.CreateProject) (*output.CreateProject, error) {
+func (u *projectUsecase) CreateProject(ctx context.Context, in *CreateProjectInput) (*CreateProjectOutput, error) {
 	groupIDVo, err := groupdm.NewGroupID(in.GroupID)
 	if err != nil {
 		return nil, err
@@ -82,7 +80,7 @@ func (u *projectUsecase) CreateProject(ctx context.Context, in *input.CreateProj
 		return nil, err
 	}
 
-	return &output.CreateProject{
+	return &CreateProjectOutput{
 		ID:                projectDm.ID().Value(),
 		GroupID:           projectDm.GroupID().Value(),
 		KeyName:           projectDm.KeyName().Value(),
@@ -95,7 +93,7 @@ func (u *projectUsecase) CreateProject(ctx context.Context, in *input.CreateProj
 
 }
 
-func (u *projectUsecase) UpdateProject(ctx context.Context, in *input.UpdateProject) (*output.UpdateProject, error) {
+func (u *projectUsecase) UpdateProject(ctx context.Context, in *UpdateProjectInput) (*UpdateProjectOutput, error) {
 	projectIDVo, err := projectdm.NewProjectID(in.ID)
 	if err != nil {
 		return nil, err
@@ -149,7 +147,7 @@ func (u *projectUsecase) UpdateProject(ctx context.Context, in *input.UpdateProj
 		return nil, err
 	}
 
-	return &output.UpdateProject{
+	return &UpdateProjectOutput{
 		ID:                projectDm.ID().Value(),
 		GroupID:           projectDm.GroupID().Value(),
 		KeyName:           projectDm.KeyName().Value(),
@@ -161,7 +159,7 @@ func (u *projectUsecase) UpdateProject(ctx context.Context, in *input.UpdateProj
 	}, nil
 }
 
-func (u *projectUsecase) FetchProjectByID(ctx context.Context, in *input.FetchProjectByID) (*output.FetchProjectByID, error) {
+func (u *projectUsecase) FetchProjectByID(ctx context.Context, in *FetchProjectByIDInput) (*FetchProjectByIDOutput, error) {
 	projectIDVo, err := projectdm.NewProjectID(in.ID)
 	if err != nil {
 		return nil, err
@@ -172,7 +170,7 @@ func (u *projectUsecase) FetchProjectByID(ctx context.Context, in *input.FetchPr
 		return nil, err
 	}
 
-	return &output.FetchProjectByID{
+	return &FetchProjectByIDOutput{
 		ID:                projectDm.ID().Value(),
 		GroupID:           projectDm.GroupID().Value(),
 		KeyName:           projectDm.KeyName().Value(),
@@ -184,15 +182,15 @@ func (u *projectUsecase) FetchProjectByID(ctx context.Context, in *input.FetchPr
 	}, nil
 }
 
-func (u *projectUsecase) FetchProjects(ctx context.Context) (output.FetchProjects, error) {
+func (u *projectUsecase) FetchProjects(ctx context.Context) (FetchProjectsOutput, error) {
 	projectsDm, err := u.projectRepository.FetchProjects(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	projectsDto := make(output.FetchProjects, len(projectsDm))
+	projectsDto := make(FetchProjectsOutput, len(projectsDm))
 	for i, projectDm := range projectsDm {
-		projectsDto[i] = &output.Project{
+		projectsDto[i] = &Project{
 			ID:                projectDm.ID().Value(),
 			GroupID:           projectDm.GroupID().Value(),
 			KeyName:           projectDm.KeyName().Value(),

--- a/pm/usecase/projectusecse/project_input.go
+++ b/pm/usecase/projectusecse/project_input.go
@@ -1,6 +1,6 @@
-package input
+package projectusecse
 
-type CreateProject struct {
+type CreateProjectInput struct {
 	GroupID           string `json:"groupID"`
 	KeyName           string `json:"keyName"`
 	Name              string `json:"name"`
@@ -8,7 +8,7 @@ type CreateProject struct {
 	DefaultAssigneeID string `json:"defaultAssigneeID"`
 }
 
-type UpdateProject struct {
+type UpdateProjectInput struct {
 	ID                string `json:"ID"`
 	GroupID           string `json:"groupID"`
 	KeyName           string `json:"keyName"`
@@ -17,6 +17,6 @@ type UpdateProject struct {
 	DefaultAssigneeID string `json:"defaultAssigneeID"`
 }
 
-type FetchProjectByID struct {
+type FetchProjectByIDInput struct {
 	ID string `json:"ID"`
 }

--- a/pm/usecase/projectusecse/project_output.go
+++ b/pm/usecase/projectusecse/project_output.go
@@ -1,8 +1,8 @@
-package output
+package projectusecse
 
 import "time"
 
-type CreateProject struct {
+type CreateProjectOutput struct {
 	ID                string    `json:"id"`
 	GroupID           string    `json:"groupID"`
 	KeyName           string    `json:"keyName"`
@@ -13,7 +13,7 @@ type CreateProject struct {
 	UpdatedAt         time.Time `json:"updatedAt"`
 }
 
-type UpdateProject struct {
+type UpdateProjectOutput struct {
 	ID                string    `json:"id"`
 	GroupID           string    `json:"groupID"`
 	KeyName           string    `json:"keyName"`
@@ -24,7 +24,7 @@ type UpdateProject struct {
 	UpdatedAt         time.Time `json:"updatedAt"`
 }
 
-type FetchProjectByID struct {
+type FetchProjectByIDOutput struct {
 	ID                string    `json:"id"`
 	GroupID           string    `json:"groupID"`
 	KeyName           string    `json:"keyName"`
@@ -35,7 +35,7 @@ type FetchProjectByID struct {
 	UpdatedAt         time.Time `json:"updatedAt"`
 }
 
-type FetchProjects []*Project
+type FetchProjectsOutput []*Project
 
 type Project struct {
 	ID                string    `json:"id"`


### PR DESCRIPTION
# 概要
- usecse配下のinput,outputディレクトリを削除
- input配下の`project.go `→ `project_input.go`へファイル名を変更し、usecse配下に移動
- output配下の`project.go `→ `project_output.go`へファイル名を変更し、usecse配下に移動
- projectinput,projectoutputで使用する構造体名にサフィックスを追加（input,output）