### PR TITLE
usecase層のupdateprojectテスト修正

### DIFF
--- a/pm/usecase/projectusecase/update_project_usecase_test.go
+++ b/pm/usecase/projectusecase/update_project_usecase_test.go
@@ -165,12 +165,38 @@ func TestUpdateProjectUsecaseUpdateProject(t *testing.T) {
 			wantErr: apperrors.NotFound,
 		},
 		{
-			name:        "keyName不正",
-			prepareMock: nil,
+			name: "keyName不正",
+			prepareMock: func(f *fields) error {
+				ctx := context.TODO()
+				var err error
+
+				projectIDVo, err := projectdm.NewProjectID("024d71d6-1d03-11ec-a478-0242ac180002")
+				if err != nil {
+					return err
+				}
+
+				projectDm, err := projectdm.Reconstruct(
+					"024d71d6-1d03-11ec-a478-0242ac180002",
+					"024d78d6-1d03-11ec-a478-0242ac180002",
+					"AAA",
+					"管理ツール1",
+					"024d78d6-1d03-11ec-a478-0242ac184402",
+					"024d78d6-1d03-11ec-a478-9242ac180002",
+					time.Date(2021, 11, 20, 0, 0, 0, 0, time.UTC),
+					time.Date(2021, 11, 20, 0, 0, 0, 0, time.UTC),
+				)
+				if err != nil {
+					return err
+				}
+
+				f.projectRepository.EXPECT().FetchProjectByIDForUpdate(ctx, projectIDVo).Return(projectDm, nil)
+
+				return nil
+			},
 			args: args{
 				ctx: context.TODO(),
 				in: &UpdateProjectInput{
-					GroupID:           "024d78d6-1d03-11ec-a478-0242ac180002",
+					ID:                "024d71d6-1d03-11ec-a478-0242ac180002",
 					KeyName:           "invalid keyName",
 					Name:              "管理ツール1",
 					LeaderID:          "024d78d6-1d03-11ec-a478-0242ac184402",

--- a/pm/usecase/projectusecase/update_project_usecase_test.go
+++ b/pm/usecase/projectusecase/update_project_usecase_test.go
@@ -364,7 +364,7 @@ func TestUpdateProjectUsecaseUpdateProject(t *testing.T) {
 				f.projectRepository.EXPECT().FetchProjectByIDForUpdate(ctx, projectIDVo).Return(projectDm, nil)
 				f.projectRepository.EXPECT().FetchProjectByID(ctx, projectIDVo).Return(nil, apperr)
 
-				return err
+				return nil
 			},
 			args: args{
 				ctx: context.TODO(),


### PR DESCRIPTION
## やったこと
<!-- このプルリクで何をしたのか? -->
usecase層のUpdateProjectテストの修正
・keyname不正のテストに、`FetchProjectByIDForUpdate`のモック
　を生成。
・argsのinで受け取るGroupIDを削除し、IDを追加。
## やらないこと
<!-- このプルリクでやらないことは何か? やらない場合、いつやるのかを明記（無いなら「無し」でOK）-->
無し

## 動作確認
<!-- どのような動作確認を行ったのか? 結果はどうか? -->
・make test
・make lint
## その他
<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）-->
