### PR TITLE
project存在確認のロジックをドメインサービスに定義

### DIFF
--- a/pm/domain/projectdm/project_domain_service.go
+++ b/pm/domain/projectdm/project_domain_service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/onituka/agile-project-management/project-management/apperrors"
+	"github.com/onituka/agile-project-management/project-management/domain/productdm"
 )
 
 type projectDomainService struct {
@@ -32,9 +33,17 @@ func (s *projectDomainService) ExistsProjectForCreate(ctx context.Context, proje
 	return false, err
 }
 
+func (s *projectDomainService) ExistsProjectByIDForUpdate(ctx context.Context, projectIDVo ProjectID, productIDVo productdm.ProductID) (bool, error) {
+	if _, err := s.projectRepository.FetchProjectByIDForUpdate(ctx, projectIDVo, productIDVo); err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
 // TODO: シンプルなロジックにリファクタ
 func (s *projectDomainService) ExistUniqueProjectForUpdate(ctx context.Context, projectDm *Project) (bool, error) {
-	oldProjectDm, err := s.projectRepository.FetchProjectByID(ctx, projectDm.ID(), projectDm.productID)
+	oldProjectDm, err := s.projectRepository.FetchProjectByID(ctx, projectDm.ID(), projectDm.ProductID())
 	if err != nil {
 		return false, apperrors.InternalServerError
 	}

--- a/pm/usecase/projectusecase/create_project_usecase.go
+++ b/pm/usecase/projectusecase/create_project_usecase.go
@@ -34,8 +34,12 @@ func (u *createProjectUsecase) CreateProject(ctx context.Context, in *projectinp
 		return nil, err
 	}
 
-	if _, err = u.productRepository.FetchProductByIDForUpdate(ctx, productIDVo); err != nil {
+	productDomainService := productdm.NewProductDomainService(u.productRepository)
+
+	if exist, err := productDomainService.ExistsProductByIDForUpdate(ctx, productIDVo); err != nil {
 		return nil, err
+	} else if !exist {
+		return nil, apperrors.NotFound
 	}
 
 	groupIDVo, err := groupdm.NewGroupID(in.GroupID)

--- a/pm/usecase/projectusecase/fetch_project_by_id_usecase.go
+++ b/pm/usecase/projectusecase/fetch_project_by_id_usecase.go
@@ -3,6 +3,7 @@ package projectusecase
 import (
 	"context"
 
+	"github.com/onituka/agile-project-management/project-management/apperrors"
 	"github.com/onituka/agile-project-management/project-management/domain/productdm"
 	"github.com/onituka/agile-project-management/project-management/domain/projectdm"
 	"github.com/onituka/agile-project-management/project-management/usecase/projectusecase/projectinput"
@@ -31,8 +32,12 @@ func (u *fetchProjectByIDUsecase) FetchProjectByID(ctx context.Context, in *proj
 		return nil, err
 	}
 
-	if _, err = u.productRepository.FetchProductByIDForUpdate(ctx, productIDVo); err != nil {
+	productDomainService := productdm.NewProductDomainService(u.productRepository)
+
+	if exist, err := productDomainService.ExistsProductByIDForUpdate(ctx, productIDVo); err != nil {
 		return nil, err
+	} else if !exist {
+		return nil, apperrors.NotFound
 	}
 
 	projectIDVo, err := projectdm.NewProjectID(in.ID)

--- a/pm/usecase/projectusecase/fetch_projects_usecase.go
+++ b/pm/usecase/projectusecase/fetch_projects_usecase.go
@@ -37,8 +37,12 @@ func (u *fetchProjectsUsecase) FetchProjects(ctx context.Context, in *projectinp
 		return nil, err
 	}
 
-	if _, err := u.productRepository.FetchProductByIDForUpdate(ctx, productIDVo); err != nil {
+	productDomainService := productdm.NewProductDomainService(u.productRepository)
+
+	if exist, err := productDomainService.ExistsProductByIDForUpdate(ctx, productIDVo); err != nil {
 		return nil, err
+	} else if !exist {
+		return nil, apperrors.NotFound
 	}
 
 	totalCount, err := u.projectQueryService.CountProjectsByProductID(ctx, productIDVo)

--- a/pm/usecase/projectusecase/restore_from_trash_project_usecase.go
+++ b/pm/usecase/projectusecase/restore_from_trash_project_usecase.go
@@ -32,13 +32,25 @@ func (u *restoreFromTrashProjectUsecase) RestoreFromTrashProject(ctx context.Con
 		return nil, err
 	}
 
-	if _, err = u.productRepository.FetchProductByIDForUpdate(ctx, productIDVo); err != nil {
+	productDomainService := productdm.NewProductDomainService(u.productRepository)
+
+	if exist, err := productDomainService.ExistsProductByIDForUpdate(ctx, productIDVo); err != nil {
 		return nil, err
+	} else if !exist {
+		return nil, apperrors.NotFound
 	}
 
 	projectIDVo, err := projectdm.NewProjectID(in.ID)
 	if err != nil {
 		return nil, err
+	}
+
+	projectDomainService := projectdm.NewProjectDomainService(u.projectRepository)
+
+	if exist, err := projectDomainService.ExistsProjectByIDForUpdate(ctx, projectIDVo, productIDVo); err != nil {
+		return nil, err
+	} else if !exist {
+		return nil, apperrors.NotFound
 	}
 
 	projectDm, err := u.projectRepository.FetchProjectByIDForUpdate(ctx, projectIDVo, productIDVo)

--- a/pm/usecase/projectusecase/restore_from_trash_project_usecase_test.go
+++ b/pm/usecase/projectusecase/restore_from_trash_project_usecase_test.go
@@ -69,8 +69,13 @@ func TestRestoreFromTrashProjectUsecaseRestoreFromTrashProject(t *testing.T) {
 				}
 
 				f.productRepository.EXPECT().FetchProductByIDForUpdate(ctx, productIDVo)
+
+				gomock.InOrder(
+					f.projectRepository.EXPECT().FetchProjectByIDForUpdate(ctx, projectIDVo, productIDVo).Return(nil, err),
+					f.projectRepository.EXPECT().FetchProjectByIDForUpdate(ctx, projectIDVo, productIDVo).Return(projectDm, err),
+				)
+
 				f.projectRepository.EXPECT().UpdateProject(ctx, gomock.Any()).Return(nil)
-				f.projectRepository.EXPECT().FetchProjectByIDForUpdate(ctx, projectIDVo, productIDVo).Return(projectDm, nil)
 
 				return nil
 			},
@@ -146,8 +151,9 @@ func TestRestoreFromTrashProjectUsecaseRestoreFromTrashProject(t *testing.T) {
 				if err != nil {
 					return err
 				}
+				apperr := apperrors.InvalidParameter
 
-				f.productRepository.EXPECT().FetchProductByIDForUpdate(ctx, productIDVo)
+				f.productRepository.EXPECT().FetchProductByIDForUpdate(ctx, productIDVo).Return(nil, apperr)
 
 				return nil
 			},
@@ -229,7 +235,12 @@ func TestRestoreFromTrashProjectUsecaseRestoreFromTrashProject(t *testing.T) {
 				apperr := apperrors.InternalServerError
 
 				f.productRepository.EXPECT().FetchProductByIDForUpdate(ctx, productIDVo).Return(nil, err)
-				f.projectRepository.EXPECT().FetchProjectByIDForUpdate(ctx, projectIDVo, productIDVo).Return(projectDm, nil)
+
+				gomock.InOrder(
+					f.projectRepository.EXPECT().FetchProjectByIDForUpdate(ctx, projectIDVo, productIDVo).Return(nil, err),
+					f.projectRepository.EXPECT().FetchProjectByIDForUpdate(ctx, projectIDVo, productIDVo).Return(projectDm, nil),
+				)
+
 				f.projectRepository.EXPECT().UpdateProject(ctx, projectDm).Return(apperr)
 
 				return nil

--- a/pm/usecase/projectusecase/search_projects_usecase.go
+++ b/pm/usecase/projectusecase/search_projects_usecase.go
@@ -37,8 +37,12 @@ func (u *searchProjectsUsecase) SearchProjects(ctx context.Context, in *projecti
 		return nil, err
 	}
 
-	if _, err := u.productRepository.FetchProductByIDForUpdate(ctx, productIDVo); err != nil {
+	productDomainService := productdm.NewProductDomainService(u.productRepository)
+
+	if exist, err := productDomainService.ExistsProductByIDForUpdate(ctx, productIDVo); err != nil {
 		return nil, err
+	} else if !exist {
+		return nil, apperrors.NotFound
 	}
 
 	totalCount, err := u.projectQueryService.CountProjectsByKeyNameAndName(ctx, productIDVo, in.KeyWord)

--- a/pm/usecase/projectusecase/trashed_project_usecase.go
+++ b/pm/usecase/projectusecase/trashed_project_usecase.go
@@ -32,13 +32,25 @@ func (u *trashedProjectUsecase) TrashedProject(ctx context.Context, in *projecti
 		return nil, err
 	}
 
-	if _, err = u.productRepository.FetchProductByIDForUpdate(ctx, productIDVo); err != nil {
+	productDomainService := productdm.NewProductDomainService(u.productRepository)
+
+	if exist, err := productDomainService.ExistsProductByIDForUpdate(ctx, productIDVo); err != nil {
 		return nil, err
+	} else if !exist {
+		return nil, apperrors.NotFound
 	}
 
 	projectIDVo, err := projectdm.NewProjectID(in.ID)
 	if err != nil {
 		return nil, err
+	}
+
+	projectDomainService := projectdm.NewProjectDomainService(u.projectRepository)
+
+	if exist, err := projectDomainService.ExistsProjectByIDForUpdate(ctx, projectIDVo, productIDVo); err != nil {
+		return nil, err
+	} else if !exist {
+		return nil, apperrors.NotFound
 	}
 
 	projectDm, err := u.projectRepository.FetchProjectByIDForUpdate(ctx, projectIDVo, productIDVo)

--- a/pm/usecase/projectusecase/trashed_project_usecase_test.go
+++ b/pm/usecase/projectusecase/trashed_project_usecase_test.go
@@ -68,9 +68,14 @@ func TestTrashedProjectUsecaseTrashedProject(t *testing.T) {
 					return err
 				}
 
-				f.productRepository.EXPECT().FetchProductByIDForUpdate(ctx, productIDVo)
+				f.productRepository.EXPECT().FetchProductByIDForUpdate(ctx, productIDVo).Return(nil, err)
+
+				gomock.InOrder(
+					f.projectRepository.EXPECT().FetchProjectByIDForUpdate(ctx, projectIDVo, productIDVo).Return(nil, err),
+					f.projectRepository.EXPECT().FetchProjectByIDForUpdate(ctx, projectIDVo, productIDVo).Return(projectDm, nil),
+				)
+
 				f.projectRepository.EXPECT().UpdateProject(ctx, gomock.Any()).Return(nil)
-				f.projectRepository.EXPECT().FetchProjectByIDForUpdate(ctx, projectIDVo, productIDVo).Return(projectDm, nil)
 
 				return nil
 			},
@@ -229,7 +234,12 @@ func TestTrashedProjectUsecaseTrashedProject(t *testing.T) {
 				apperr := apperrors.InternalServerError
 
 				f.productRepository.EXPECT().FetchProductByIDForUpdate(ctx, productIDVo).Return(nil, err)
-				f.projectRepository.EXPECT().FetchProjectByIDForUpdate(ctx, projectIDVo, productIDVo).Return(projectDm, nil)
+
+				gomock.InOrder(
+					f.projectRepository.EXPECT().FetchProjectByIDForUpdate(ctx, projectIDVo, productIDVo).Return(nil, err),
+					f.projectRepository.EXPECT().FetchProjectByIDForUpdate(ctx, projectIDVo, productIDVo).Return(projectDm, nil),
+				)
+
 				f.projectRepository.EXPECT().UpdateProject(ctx, projectDm).Return(apperr)
 
 				return nil

--- a/pm/usecase/projectusecase/update_project_usecase_test.go
+++ b/pm/usecase/projectusecase/update_project_usecase_test.go
@@ -102,11 +102,16 @@ func TestUpdateProjectUsecaseUpdateProject(t *testing.T) {
 				apperr := apperrors.NotFound
 
 				f.productRepository.EXPECT().FetchProductByIDForUpdate(ctx, productIDVo).Return(nil, err)
-				f.projectRepository.EXPECT().UpdateProject(ctx, gomock.Any()).Return(nil)
-				f.projectRepository.EXPECT().FetchProjectByIDForUpdate(ctx, projectIDVo, productIDVo).Return(projectDm, nil)
-				f.projectRepository.EXPECT().FetchProjectByID(ctx, projectIDVo, productIDVo).Return(oldProjectDm, nil)
+				f.projectRepository.EXPECT().FetchProjectByIDForUpdate(ctx, projectIDVo, productIDVo).Return(nil, err)
+
+				gomock.InOrder(
+					f.projectRepository.EXPECT().FetchProjectByID(ctx, projectIDVo, productIDVo).Return(projectDm, nil),
+					f.projectRepository.EXPECT().FetchProjectByID(ctx, projectIDVo, productIDVo).Return(oldProjectDm, nil),
+				)
+
 				f.projectRepository.EXPECT().FetchProjectByGroupIDAndKeyName(ctx, groupIDVo, keyNameVo).Return(nil, apperr)
 				f.projectRepository.EXPECT().FetchProjectByGroupIDAndName(ctx, groupIDVo, nameVo).Return(nil, apperr)
+				f.projectRepository.EXPECT().UpdateProject(ctx, gomock.Any()).Return(nil)
 
 				return nil
 			},
@@ -274,7 +279,8 @@ func TestUpdateProjectUsecaseUpdateProject(t *testing.T) {
 				}
 
 				f.productRepository.EXPECT().FetchProductByIDForUpdate(ctx, productIDVo).Return(nil, err)
-				f.projectRepository.EXPECT().FetchProjectByIDForUpdate(ctx, projectIDVo, productIDVo).Return(projectDm, nil)
+				f.projectRepository.EXPECT().FetchProjectByIDForUpdate(ctx, projectIDVo, productIDVo).Return(projectDm, err)
+				f.projectRepository.EXPECT().FetchProjectByID(ctx, projectIDVo, productIDVo).Return(projectDm, nil)
 
 				return nil
 			},
@@ -326,6 +332,7 @@ func TestUpdateProjectUsecaseUpdateProject(t *testing.T) {
 
 				f.productRepository.EXPECT().FetchProductByIDForUpdate(ctx, productIDVo).Return(nil, err)
 				f.projectRepository.EXPECT().FetchProjectByIDForUpdate(ctx, projectIDVo, productIDVo).Return(projectDm, nil)
+				f.projectRepository.EXPECT().FetchProjectByID(ctx, projectIDVo, productIDVo).Return(projectDm, nil)
 
 				return nil
 			},
@@ -377,6 +384,7 @@ func TestUpdateProjectUsecaseUpdateProject(t *testing.T) {
 
 				f.productRepository.EXPECT().FetchProductByIDForUpdate(ctx, productIDVo).Return(nil, err)
 				f.projectRepository.EXPECT().FetchProjectByIDForUpdate(ctx, projectIDVo, productIDVo).Return(projectDm, nil)
+				f.projectRepository.EXPECT().FetchProjectByID(ctx, projectIDVo, productIDVo).Return(projectDm, nil)
 
 				return nil
 			},
@@ -428,6 +436,7 @@ func TestUpdateProjectUsecaseUpdateProject(t *testing.T) {
 
 				f.productRepository.EXPECT().FetchProductByIDForUpdate(ctx, productIDVo).Return(nil, err)
 				f.projectRepository.EXPECT().FetchProjectByIDForUpdate(ctx, projectIDVo, productIDVo).Return(projectDm, nil)
+				f.projectRepository.EXPECT().FetchProjectByID(ctx, projectIDVo, productIDVo).Return(projectDm, nil)
 
 				return nil
 			},
@@ -481,7 +490,11 @@ func TestUpdateProjectUsecaseUpdateProject(t *testing.T) {
 
 				f.productRepository.EXPECT().FetchProductByIDForUpdate(ctx, productIDVo).Return(nil, err)
 				f.projectRepository.EXPECT().FetchProjectByIDForUpdate(ctx, projectIDVo, productIDVo).Return(projectDm, nil)
-				f.projectRepository.EXPECT().FetchProjectByID(ctx, projectIDVo, productIDVo).Return(nil, apperr)
+
+				gomock.InOrder(
+					f.projectRepository.EXPECT().FetchProjectByID(ctx, projectIDVo, productIDVo).Return(projectDm, nil),
+					f.projectRepository.EXPECT().FetchProjectByID(ctx, projectIDVo, productIDVo).Return(nil, apperr),
+				)
 
 				return nil
 			},


### PR DESCRIPTION
## やったこと
<!-- このプルリクで何をしたのか? -->
puroductで指摘項目修正
usecase層で使用していたpuroductの存在確認関数の変更。
　・`productByForUpdate` → `ExistsproductByForUpdate`へ変更

project存在確認のロジックをドメインサービスに定義
　

## やらないこと
<!-- このプルリクでやらないことは何か? やらない場合、いつやるのかを明記（無いなら「無し」でOK）-->
無し

## Request, Response 例
<!--
### Request
Method: GET  
Path: /example

<details>
<summary>body(click):</summary>

```
{
    "key": "example"
}
```

</details>

### Response

<details>
<summary>body(click):</summary>

```
{
    "key": "example"
}
```

</details>
-->

## 動作確認
<!-- どのような動作確認を行ったのか? 結果はどうか? -->
・postmanにて挙動確認
・make run
・make lint
・make test

## その他
<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）-->
テスト修正もこのプルリク内で行います。