### PR TITLE
プルリクclose時にswagger通知workflowが発火するようトリガー修正

### DIFF
--- a/.github/workflows/swagger-notify.yaml
+++ b/.github/workflows/swagger-notify.yaml
@@ -1,8 +1,7 @@
 name: Swagger change notification
 on:
-  push:
-    branches:
-      - main
+  pull_request:
+    types: [ closed ]
     paths:
       - swagger/**
       - .github/workflows/swagger-notify.yaml


### PR DESCRIPTION
## やったこと
<!-- このプルリクで何をしたのか? -->
プルリクclose時にswagger通知workflowが発火するようトリガー修正

## やらないこと
<!-- このプルリクでやらないことは何か? やらない場合、いつやるのかを明記（無いなら「無し」でOK）-->
無し

## 動作確認
<!-- どのような動作確認を行ったのか? 結果はどうか? -->


## その他
<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）-->
こちらは`pullRequest`の箇所が`n/a`になってしまう事に対する、対応プルリクです。
<img width="470" alt="スクリーンショット 2022-02-13 15 27 18" src="https://user-images.githubusercontent.com/59386359/153741622-724e94f1-95b6-4aff-b797-7008c7486b01.png">